### PR TITLE
Add support for Two Factor Authentication

### DIFF
--- a/Instagram Reels Bot/Helpers/InstagramProcessor.cs
+++ b/Instagram Reels Bot/Helpers/InstagramProcessor.cs
@@ -427,6 +427,12 @@ namespace Instagram_Reels_Bot.Helpers
 			// build the configuration and assign to _config          
 			var config = _builder.Build();
 
+            // Check to ensure that 2FASecret is set:
+            if (string.IsNullOrEmpty(config["2FASecret"]))
+            {
+				throw new ArgumentException("2FASecret config not set.");
+			}
+
 			//Convert secret:
 			var bytes = Base32Encoding.ToBytes(config["2FASecret"]);
 			var totp = new Totp(bytes);

--- a/Instagram Reels Bot/Helpers/InstagramProcessor.cs
+++ b/Instagram Reels Bot/Helpers/InstagramProcessor.cs
@@ -382,7 +382,7 @@ namespace Instagram_Reels_Bot.Helpers
 					//Try to log in:
 					string code = GetTwoFactorAuthCode();
 					Console.WriteLine(code);
-					var twoFAlogInResult = instaApi.TwoFactorLoginAsync(code).GetAwaiter().GetResult();
+					var twoFAlogInResult = instaApi.TwoFactorLoginAsync(code, 0).GetAwaiter().GetResult();
 					if (!twoFAlogInResult.Succeeded)
 					{
 						Console.WriteLine("Failed to log in with 2FA.");

--- a/Instagram Reels Bot/Helpers/InstagramProcessor.cs
+++ b/Instagram Reels Bot/Helpers/InstagramProcessor.cs
@@ -417,6 +417,11 @@ namespace Instagram_Reels_Bot.Helpers
 				Console.WriteLine("Error writing state file. Error: " + e);
 			}
 		}
+		/// <summary>
+        /// Gets the 2FA OTP.
+        /// </summary>
+        /// <returns>A 2FA Auth code</returns>
+        /// <exception cref="ArgumentException">Thrown if 2FASecret is not set in the config.</exception>
 		public static string GetTwoFactorAuthCode()
         {
 			// create the configuration

--- a/Instagram Reels Bot/Instagram Reels Bot.csproj
+++ b/Instagram Reels Bot/Instagram Reels Bot.csproj
@@ -17,12 +17,14 @@
     <PackageReference Include="OpenGraph-Net" Version="3.2.8" />
     <PackageReference Include="InstagramApiSharp" Version="1.7.1" />
     <PackageReference Include="Discord.Net.Interactions" Version="3.1.0" />
+    <PackageReference Include="Otp.NET" Version="1.2.2" />
   </ItemGroup>
 
   <ItemGroup>
     <None Remove="InstagramApiSharp" />
     <None Remove="Discord.Net.Interactions" />
     <None Remove="InstagramHelpers\" />
+    <None Remove="Otp.NET" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Helpers\" />

--- a/Instagram Reels Bot/Instagram Reels Bot.csproj
+++ b/Instagram Reels Bot/Instagram Reels Bot.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="OpenGraph-Net" Version="3.2.8" />
-    <PackageReference Include="InstagramApiSharp" Version="1.7.1" />
     <PackageReference Include="Discord.Net.Interactions" Version="3.1.0" />
     <PackageReference Include="Otp.NET" Version="1.2.2" />
+    <PackageReference Include="Bman46InstagramApiSharpLabs" Version="1.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Instagram Reels Bot/Program.cs
+++ b/Instagram Reels Bot/Program.cs
@@ -51,7 +51,6 @@ namespace Instagram_Reels_Bot
                 .UseLogger(new DebugLogger(LogLevel.Exceptions))
                 .Build();
             InstagramProcessor.InstagramLogin();
-
         }
 
         public async Task MainAsync()

--- a/Instagram Reels Bot/Services/CommandHandler.cs
+++ b/Instagram Reels Bot/Services/CommandHandler.cs
@@ -153,6 +153,14 @@ namespace Instagram_Reels_Bot.Services
                         InstagramProcessor.InstagramLogin(true, true);
                         await message.ReplyAsync("Success");
                     }
+                }else if (message.Content.ToLower().StartsWith("2facode"))
+                {
+                    if (!string.IsNullOrEmpty(_config["OwnerID"]) && message.Author.Id == ulong.Parse(_config["OwnerID"]))
+                    {
+                        //Clear login information and relogin:
+                        var code = InstagramProcessor.GetTwoFactorAuthCode();
+                        await message.ReplyAsync("2FA Code: "+code);
+                    }
                 }
                 return;
             }

--- a/Instagram Reels Bot/Services/CommandHandler.cs
+++ b/Instagram Reels Bot/Services/CommandHandler.cs
@@ -158,8 +158,15 @@ namespace Instagram_Reels_Bot.Services
                     if (!string.IsNullOrEmpty(_config["OwnerID"]) && message.Author.Id == ulong.Parse(_config["OwnerID"]))
                     {
                         //Clear login information and relogin:
-                        var code = InstagramProcessor.GetTwoFactorAuthCode();
-                        await message.ReplyAsync("2FA Code: "+code);
+                        try
+                        {
+                            var code = InstagramProcessor.GetTwoFactorAuthCode();
+                            await message.ReplyAsync("2FA Code: " + code);
+                        }catch(Exception e)
+                        {
+                            await message.ReplyAsync("Failed to get 2FA code.");
+                            Console.WriteLine("2FA Code error: " + e);
+                        }
                     }
                 }
                 return;


### PR DESCRIPTION
Add support for 2FA to help to increase account trust with Instagram. 2FA codes are generated by the bot and can should be configured using the authenticator app option in Instagram. Note that this does not support SMS.

Change Note: Switched to custom branch of InstagramAPISharp maintained by me.