### PR TITLE
Add option for delay between account syncs

### DIFF
--- a/Instagram Reels Bot/Services/Subscriptions.cs
+++ b/Instagram Reels Bot/Services/Subscriptions.cs
@@ -431,9 +431,14 @@ namespace Instagram_Reels_Bot.Services
                             }
                             //Update database:
                             await this.FollowedAccountsContainer.ReplaceOneAsync(x => x.InstagramID == dbfeed.InstagramID, dbfeed, new ReplaceOptions { IsUpsert = true });
-                            // Wait to prevent spamming IG api:
-                            // 10 seconds
-                            await Task.Delay(10000);
+
+                            // Wait to prevent spamming IG api
+                            // Get value from config:
+                            int time = 10;
+                            int.TryParse(_config["SubscribeCheckDelayTime"], out time);
+                            // Enforce a minimum of 10 seconds.
+                            time = Math.Max(time, 10);
+                            await Task.Delay(time * 1000);
                         }
                     }
                     catch(Exception e)

--- a/Instagram Reels Bot/Services/Subscriptions.cs
+++ b/Instagram Reels Bot/Services/Subscriptions.cs
@@ -434,8 +434,8 @@ namespace Instagram_Reels_Bot.Services
 
                             // Wait to prevent spamming IG api
                             // Get value from config:
-                            int time = 10;
-                            int.TryParse(_config["SubscribeCheckDelayTime"], out time);
+                            int time;
+                            _ = int.TryParse(_config["SubscribeCheckDelayTime"], out time);
                             // Enforce a minimum of 10 seconds.
                             time = Math.Max(time, 10);
                             await Task.Delay(time * 1000);

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Create a new file named `config.json`, copy and paste the contents below into it
   "AllowSubscriptions": true/false,
   "MongoDBUrl": "MongoDB Connection String (Required for subscriptions)",
   "DefaultSubscriptionsPerGuildMax": 1,
-  "HoursToCheckForNewContent": 3
+  "HoursToCheckForNewContent": 3,
+  "SubscribeCheckDelayTime": 10
 }
 ```


### PR DESCRIPTION
Adds an option to customize the delay increment between account subscribe checks to the config. A minimum of 10 seconds between accounts is enforced.

config.json:
```json
"SubscribeCheckDelayTime": 10
```