### PR TITLE
Revert "Bump file upload size"

### DIFF
--- a/Instagram Reels Bot/Helpers/Discord/DiscordTools.cs
+++ b/Instagram Reels Bot/Helpers/Discord/DiscordTools.cs
@@ -109,8 +109,8 @@ namespace Instagram_Reels_Bot.Helpers
                     //Tier 3 100MB Upload Limit
                     return 100000000;
                 default:
-                    //Default 25MB Upload Limit
-                    return 25000000;
+                    //Default 8MB Upload Limit
+                    return 8000000;
             }
         }
         #endregion


### PR DESCRIPTION
Reverts bman46/InstagramEmbedDiscordBot#68

It appears that the API did not increase the upload size limit for bots. Reverting until more information on what was increased is available.

Fixes #69